### PR TITLE
Changing PreferencesDialog constructor to match function calls

### DIFF
--- a/app.py
+++ b/app.py
@@ -88,7 +88,7 @@ class Application(QApplication):
         fileMenu.addAction(settingsAction)
 
     def showPreferencesDialog(self):
-        dlg = PreferencesDialog(self.mainwindow)
+        dlg = PreferencesDialog(self)
         dlg.exec()
 
     def setPDF(self, path):

--- a/preferences.py
+++ b/preferences.py
@@ -8,14 +8,13 @@ from PyQt6.QtGui import QIcon, QAction
 
 
 class PreferencesDialog(QDialog):
-    def __init__(self, parent, app):
-        super().__init__(parent)
+    def __init__(self, app):
+        super().__init__(app.mainwindow)
         self.setWindowTitle('Preferences')
         self.layout = QGridLayout()
         self.setLayout(self.layout)
-        self.parent = parent
         self.app = app
-        self.settings = self.parent.settings
+        self.settings = self.app.settings
         self.redraw()
 
     def redraw(self):

--- a/projectorpdfsettings.py
+++ b/projectorpdfsettings.py
@@ -69,7 +69,7 @@ class ProjectorPDFSettings(QGroupBox):
         b.clicked.connect(self.projectorcanvas.redraw)
 
         def openPrefs():
-            dlg = PreferencesDialog(self.app.mainwindow)
+            dlg = PreferencesDialog(self.app)
             dlg.exec()
 
         cal = QPushButton('Calibrate')


### PR DESCRIPTION
Hi! I was testing out projectorview under Linux and I found that it was crashing when I tried to open the preferences dialog, so I changed the constructor to just take the app instead of both app and mainwindow.

Super cool project, I'm excited to see more stuff happening in the projector world!